### PR TITLE
Shared extended for the eventid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.1.4
+- Extended for get the eventid 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins{
 
 jar {
     baseName = 'remrem-shared'
-    version =  '0.1.3'
+    version =  '0.1.4'
 }
 
 group 'com.ericsson.eiffel.remrem'

--- a/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
@@ -1,15 +1,26 @@
 package com.ericsson.eiffel.remrem.shared;
 
-
 import com.google.gson.JsonObject;
 
 public interface MsgService {
-    
+
     String EVENT_ID = "eventId";
     String ID = "id";
     String META = "meta";
     String EIFFEL_MESSAGE_VERSIONS = "eiffelMessageVersions";
-    
+
+    /**
+     * 
+     * @param msgType
+     * @param bodyJson
+     * @return
+     */
     String generateMsg(String msgType, JsonObject bodyJson);
+
+    /**
+     * Get the event id from json object.
+     * @param bodyJson
+     * @return
+     */
     String getEventId(JsonObject bodyJson);
 }

--- a/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
@@ -4,5 +4,12 @@ package com.ericsson.eiffel.remrem.shared;
 import com.google.gson.JsonObject;
 
 public interface MsgService {
+    
+    String EVENT_ID = "eventId";
+    String ID = "id";
+    String META = "meta";
+    String EIFFEL_MESSAGE_VERSIONS = "eiffelMessageVersions";
+    
     String generateMsg(String msgType, JsonObject bodyJson);
+    String getEventId(JsonObject bodyJson);
 }

--- a/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
@@ -4,11 +4,6 @@ import com.google.gson.JsonObject;
 
 public interface MsgService {
 
-    String EVENT_ID = "eventId";
-    String ID = "id";
-    String META = "meta";
-    String EIFFEL_MESSAGE_VERSIONS = "eiffelMessageVersions";
-
     /**
      * 
      * @param msgType
@@ -18,9 +13,9 @@ public interface MsgService {
     String generateMsg(String msgType, JsonObject bodyJson);
 
     /**
-     * Get the event id from json object.
-     * @param bodyJson
-     * @return
+     * Returns the Event Id from the json object. 
+     * @param JsonObject bodyJson
+     * @return the eventId from json object if event id not available then returns the null value
      */
     String getEventId(JsonObject bodyJson);
 }

--- a/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/shared/MsgService.java
@@ -5,10 +5,10 @@ import com.google.gson.JsonObject;
 public interface MsgService {
 
     /**
-     * 
-     * @param msgType
-     * @param bodyJson
-     * @return
+     * Generates the event as string from the input json Object based on the message type.
+     * @param String msgType
+     * @param JsonObject bodyJson
+     * @return the generated event as string format
      */
     String generateMsg(String msgType, JsonObject bodyJson);
 


### PR DESCRIPTION
Shared we added method getEventId, which is used in remrem-publish, prepare output format with eventId.
