### PR TITLE
Uplifted eiffel-remrem-parent version from 0.0.5 to 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+- Uplifted eiffel-remrem-parent version from 0.0.5 to 0.0.6
+  Upgraded Jackson.databind.version from 2.9.4 to 2.9.5 in parent 0.0.6 version
+- Uplifted eiffel-remrem-shared version from 0.3.9 to 0.4.0
+ 
 ## 0.3.8
 - Updated eiffel-remrem-parent version
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.5</version>
+        <version>0.0.6</version>
     </parent>
     <artifactId>eiffel-remrem-shared</artifactId>
-    <version>0.3.9</version>
+    <version>0.4.0</version>
     <packaging>jar</packaging>
     <repositories>
         <repository>


### PR DESCRIPTION
eiffel-remrem-shared version from 0.3.9 to 0.4.0.

