### PR TITLE
Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2
+- Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8.
+
 ## 0.4.1
 - Upgraded eiffel-remrem-parent version from 0.0.6 to 0.0.7.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.7</version>
+        <version>0.0.8</version>
     </parent>
     <artifactId>eiffel-remrem-shared</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <packaging>jar</packaging>
     <repositories>
         <repository>


### PR DESCRIPTION
### Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8

Upgraded the jackson-databind version in remrem-parent to 2.9.8.