### PR TITLE
Uplifted eiffel-remrem-parent version from 0.0.8 to 1.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+- Upgraded eiffel-remrem-parent version from 0.0.8 to 1.0.0.
+
 ## 0.4.2
 - Upgraded eiffel-remrem-parent version from 0.0.7 to 0.0.8.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.8</version>
+        <version>1.0.0</version>
     </parent>
     <artifactId>eiffel-remrem-shared</artifactId>
-    <version>0.4.2</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
     <repositories>
         <repository>


### PR DESCRIPTION
### Uplifted the remrem components to 1.0.0

Uplifted eiffel-remrem-parent version from 0.0.8 to 1.0.0.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
